### PR TITLE
Improve reliability of Watcher

### DIFF
--- a/Ylp.GitDb.Tests/Watcher/Branching.cs
+++ b/Ylp.GitDb.Tests/Watcher/Branching.cs
@@ -16,10 +16,9 @@ namespace Ylp.GitDb.Tests.Watcher
 
         [Fact]
         public void RaisesABranchAddedEvent() =>
-            Subject.ShouldRaise("BranchAdded")
-                   .WithArgs<BranchAdded>(args => args.BaseBranch == "master" &&
-                                                  args.Branch.Name == "test" && 
-                                                  args.Branch.Commit == Repo.Branches["master"].Tip.Sha);
+           BranchAdded.Should().Contain(args => args.BaseBranch == "master" &&
+                                                args.Branch.Name == "test" && 
+                                                args.Branch.Commit == Repo.Branches["master"].Tip.Sha);
     }
 
     public class AddingABranchAtACommitFromADifferentBranch : WithWatcher
@@ -36,11 +35,10 @@ namespace Ylp.GitDb.Tests.Watcher
 
         [Fact]
         public void RaisesABranchAddedEvent() =>
-            Subject.ShouldRaise("BranchAdded")
-                   .WithArgs<BranchAdded>(args => args.BaseBranch == "master" &&
-                                                  args.Branch.Name == "test" &&
-                                                  args.Branch.Commit == _pointer &&
-                                                  args.Deleted.Any());
+            BranchAdded.Should().Contain(args => args.BaseBranch == "master" &&
+                                                 args.Branch.Name == "test" &&
+                                                 args.Branch.Commit == _pointer &&
+                                                 args.Deleted.Any());
     }
 
     public class RemovingABranch : WithWatcher
@@ -53,7 +51,6 @@ namespace Ylp.GitDb.Tests.Watcher
 
         [Fact]
         public void RaisesABranchAddedEvent() =>
-            Subject.ShouldRaise("BranchRemoved")
-                   .WithArgs<BranchRemoved>(args => args.Branch.Name == "master");
+            BranchRemoved.Should().Contain(args => args.Branch.Name == "master");
     }
 }

--- a/Ylp.GitDb.Tests/Watcher/ModifyingBranches.cs
+++ b/Ylp.GitDb.Tests/Watcher/ModifyingBranches.cs
@@ -15,9 +15,8 @@ namespace Ylp.GitDb.Tests.Watcher
 
         [Fact]
         public void RaisesBranchChangedEvent() =>
-            Subject.ShouldRaise("BranchChanged")
-                   .WithArgs<BranchChanged>(args => args.Branch.Name == "master" &&
-                                                    args.Added.Any(item => item.Key == "key" && item.Value == "value"));
+            BranchChanged.Should().Contain(args => args.Branch.Name == "master" &&
+                                                   args.Added.Any(item => item.Key == "key" && item.GetValue() == "value"));
     }
 
     public class RemovingAFile : WithWatcher
@@ -30,9 +29,8 @@ namespace Ylp.GitDb.Tests.Watcher
 
         [Fact]
         public void RaisesBranchChangedEvent() =>
-            Subject.ShouldRaise("BranchChanged")
-                   .WithArgs<BranchChanged>(args => args.Branch.Name == "master" &&
-                                                    args.Deleted.Any(item => item.Key == "key"));
+            BranchChanged.Should().Contain(args => args.Branch.Name == "master" &&
+                                                   args.Deleted.Any(item => item.Key == "key"));
     }
 
     public class ModifyingAFile : WithWatcher
@@ -45,11 +43,10 @@ namespace Ylp.GitDb.Tests.Watcher
 
         [Fact]
         public void RaisesBranchChangedEvent() =>
-            Subject.ShouldRaise("BranchChanged")
-                   .WithArgs<BranchChanged>(args => args.Branch.Name == "master" &&
+            BranchChanged.Should().Contain(args => args.Branch.Name == "master" &&
                                                     args.Modified.Any(item => item.Key == "key" &&
-                                                                              item.Value == "value2" &&
-                                                                              item.OldValue == "value"));   
+                                                                              item.GetValue() == "value2" &&
+                                                                              item.GetOldValue() == "value"));   
     }
 
     public class RenamingAFile : WithWatcher
@@ -69,11 +66,10 @@ namespace Ylp.GitDb.Tests.Watcher
 
         [Fact]
         public void RaisesBranchChangedEvent() =>
-            Subject.ShouldRaise("BranchChanged")
-                   .WithArgs<BranchChanged>(args => args.Branch.Name == "master" &&
+            BranchChanged.Should().Contain(args => args.Branch.Name == "master" &&
                                                     args.Renamed.Any(item => item.Key == "subdir\\key" &&
                                                                              item.OldKey == "key" && 
-                                                                             item.Value == "value" &&
-                                                                             item.OldValue == "value"));
+                                                                             item.GetValue() == "value" &&
+                                                                             item.GetOldValue() == "value"));
     }
 }

--- a/Ylp.GitDb.Watcher/ItemDetails.cs
+++ b/Ylp.GitDb.Watcher/ItemDetails.cs
@@ -1,16 +1,18 @@
+using System;
+
 namespace Ylp.GitDb.Watcher
 {
     public class ItemAdded
     {
         public string Key { get; set; }
-        public string Value { get; set; }
+        public Func<string> GetValue { get; set; }
     }
     public class ItemDeleted : ItemAdded
     {
     }
     public class ItemModified : ItemAdded
     {
-        public string OldValue { get; set; }
+        public Func<string> GetOldValue { get; set; }
     }
     public class ItemRenamed : ItemModified
     {

--- a/Ylp.GitDb.Watcher/Properties/AssemblyInfo.cs
+++ b/Ylp.GitDb.Watcher/Properties/AssemblyInfo.cs
@@ -14,4 +14,4 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("e3eba271-650e-4482-bdea-41f569051b4d")]
 
-[assembly: AssemblyVersion("0.9.1")]
+[assembly: AssemblyVersion("0.10.0")]

--- a/Ylp.GitDb.Watcher/Watcher.cs
+++ b/Ylp.GitDb.Watcher/Watcher.cs
@@ -2,47 +2,46 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using LibGit2Sharp;
 using NLog;
 
 namespace Ylp.GitDb.Watcher
 {
-    public delegate void BranchAddedHandler(BranchAdded branchAdded);
-    public delegate void BranchRemovedHandler(BranchRemoved branchRemoved);
-    public delegate void BranchChangedHandler(BranchChanged branchChanged);
-
     public class Watcher : IDisposable
     {
         readonly Logger _logger;
         readonly int _interval;
+        readonly Func<BranchAdded, Task> _branchAdded;
+        readonly Func<BranchChanged, Task> _branchChanged;
+        readonly Func<BranchRemoved, Task> _branchRemoved;
         readonly Repository _repo;
         Timer _timer;
         BranchDictionary _branches;
 
-        public event BranchAddedHandler BranchAdded;
-        public event BranchRemovedHandler BranchRemoved;
-        public event BranchChangedHandler BranchChanged;
-
-        public Watcher(string path, int interval)
+        public Watcher(string path, int interval, Func<BranchAdded, Task> branchAdded, Func<BranchChanged, Task> branchChanged, Func<BranchRemoved, Task> branchRemoved)
         {
             _logger = LogManager.GetLogger("watcher");
             _interval = interval;
+            _branchAdded = branchAdded;
+            _branchChanged = branchChanged;
+            _branchRemoved = branchRemoved;
             _repo = new Repository(path);
             _branches = _repo.Branches
                              .Where(b => !b.IsRemote)
                              .ToBranchDictionary();
         }
 
-        public void Start(IEnumerable<BranchInfo> branchInfo)
+        public async Task Start(IEnumerable<BranchInfo> branchInfo)
         {
             var previousBranches = branchInfo.ToBranchDictionary();
 
-            raiseEventsForDifferences(previousBranches, _branches);
+            await raiseEventsForDifferences(previousBranches, _branches);
 
-            _timer = new Timer(check, null, _interval, Timeout.Infinite);
+            _timer = new Timer(state => check().Wait(), null, _interval, Timeout.Infinite);
         }
 
-        void check(object state)
+        async Task check()
         {
             var previousBranches = _branches;
             var currentBranches = _repo.Branches
@@ -50,24 +49,26 @@ namespace Ylp.GitDb.Watcher
                                        .ToBranchDictionary();
             _branches = currentBranches;
 
-            raiseEventsForDifferences(previousBranches, currentBranches);
+            await raiseEventsForDifferences(previousBranches, currentBranches);
 
             _timer.Change(_interval, Timeout.Infinite);
         }
 
-        void raiseEventsForDifferences(BranchDictionary previousBranches, BranchDictionary currentBranches)
+        async Task raiseEventsForDifferences(BranchDictionary previousBranches, BranchDictionary currentBranches)
         {
-            currentBranches.Where(current => previousBranches.HasBranch(current.Name) && current.Commit != previousBranches[current.Name].Commit)
-                           .ForEach(branchInfo => raiseBranchChanged(previousBranches, branchInfo));
+            foreach (var branchInfo in currentBranches.Where(current => previousBranches.HasBranch(current.Name) && current.Commit != previousBranches[current.Name].Commit))
+                await raiseBranchChanged(previousBranches, branchInfo);
+                           
 
-            currentBranches.Where(current => !previousBranches.HasBranch(current.Name))
-                           .ForEach(raiseBranchAdded);
+            foreach (var branchInfo in currentBranches.Where(current => !previousBranches.HasBranch(current.Name)))
+                await raiseBranchAdded(branchInfo);
+                           
 
-            previousBranches.Where(current => !currentBranches.HasBranch(current.Name))
-                            .ForEach(raiseBranchDeleted);
+            foreach (var branchInfo in previousBranches.Where(current => !currentBranches.HasBranch(current.Name)))
+                await raiseBranchDeleted(branchInfo);
         }
 
-        void raiseBranchChanged(BranchDictionary previousBranches, BranchInfo branch)
+        async Task raiseBranchChanged(BranchDictionary previousBranches, BranchInfo branch)
         {
             try
             {
@@ -80,7 +81,7 @@ namespace Ylp.GitDb.Watcher
                 var eventInfo = getBranchChanged<BranchChanged>(result, branch);
                 eventInfo.PreviousCommit = previousCommit.Sha;
 
-                BranchChanged?.Invoke(eventInfo);
+                await _branchChanged(eventInfo);
             }
             catch (Exception ex)
             {
@@ -89,50 +90,20 @@ namespace Ylp.GitDb.Watcher
             }
         }
 
-        void raiseBranchAdded(BranchInfo branch)
+        async Task raiseBranchAdded(BranchInfo branch)
         {
             try
             {
                 _logger.Info($"Detected a new branch {branch.Name}");
                 var currentCommit = _repo.Lookup<Commit>(branch.Commit);
-                var previousCommit = currentCommit;
-                string baseBranch;
-                _logger.Trace("Searching a base branch");
-
-                do
-                {
-                    baseBranch = _repo.Branches.FirstOrDefault(b => b.Tip.Sha == previousCommit.Sha && b.FriendlyName != branch.Name && !b.IsRemote)?.FriendlyName;
-                    if (baseBranch == null)
-                        previousCommit = previousCommit.Parents.FirstOrDefault();
-                } while (baseBranch == null && previousCommit != null);
-
-                if (previousCommit == null)
-                {
-                    var otherBranch = _repo.Branches.FirstOrDefault(b => b.FriendlyName != branch.Name && !b.IsRemote);
-                    if (otherBranch != null)
-                    {
-                        previousCommit = otherBranch.Tip;
-                        baseBranch = otherBranch.FriendlyName;
-                        _logger.Trace($"Could not find a base branch for the newly created branch {branch.Name}, taking {baseBranch} and starting diff between {previousCommit.Sha} and {currentCommit.Sha}");
-                    }
-                    else
-                    {
-                        _logger.Trace($"Could not find any base branch for the newly created branch {branch.Name}, diffing vs the very first commit");
-                        baseBranch = null;
-                        previousCommit = _repo.Branches.First(b => b.FriendlyName == branch.Name).Commits.Last();
-                    }
-                }
-                else
-                {
-                    _logger.Trace($"Found base branch {baseBranch} for {branch.Name}, starting diff between {previousCommit.Sha} and {currentCommit.Sha}");
-                }
-
+                var previousCommit = _repo.Branches["master"].Tip;
+                
                 var result = _repo.Diff.Compare<TreeChanges>(previousCommit.Tree, currentCommit.Tree);
                 _logger.Info($"Finished diff, found {result.Added.Count()} added items, {result.Deleted.Count()} deleted items, {result.Renamed.Count()} renamed items and {result.Modified.Count()} modified items");
 
                 var eventInfo = getBranchChanged<BranchAdded>(result, branch);
-                eventInfo.BaseBranch = baseBranch;
-                BranchAdded?.Invoke(eventInfo);
+                eventInfo.BaseBranch = "master";
+                await _branchAdded(eventInfo);
 
             }
             catch (Exception ex)
@@ -142,12 +113,12 @@ namespace Ylp.GitDb.Watcher
             }
         }
 
-        void raiseBranchDeleted(BranchInfo branchInfo)
+        async Task raiseBranchDeleted(BranchInfo branchInfo)
         {
             try
             {
                 _logger.Info($"Detected deletion of branch {branchInfo.Name}");
-                BranchRemoved?.Invoke(new BranchRemoved { Branch = branchInfo });
+                await _branchRemoved(new BranchRemoved {Branch = branchInfo});
             }
             catch (Exception ex)
             {
@@ -163,22 +134,22 @@ namespace Ylp.GitDb.Watcher
                 Added = changes.Added.Select(a => new ItemAdded
                 {
                     Key = a.Path,
-                    Value = getBlobValue(a.Oid)
+                    GetValue = () => getBlobValue(a.Oid)
                 }).ToList(),
                 Modified = changes.Modified.Select(m => new ItemModified
                 {
                     Key = m.Path,
-                    Value = getBlobValue(m.Oid),
-                    OldValue = getBlobValue(m.OldOid)
+                    GetValue = () => getBlobValue(m.Oid),
+                    GetOldValue = () => getBlobValue(m.OldOid)
                 }).ToList(),
                 Renamed = changes.Renamed.Select(r => new ItemRenamed
                 {
                     Key = r.Path,
-                    Value = getBlobValue(r.Oid),
-                    OldValue = getBlobValue(r.OldOid),
+                    GetValue = () => getBlobValue(r.Oid),
+                    GetOldValue = () => getBlobValue(r.OldOid),
                     OldKey = r.OldPath
                 }).ToList(),
-                Deleted = changes.Deleted.Select(d => new ItemDeleted {Key = d.Path, Value = getBlobValue(d.OldOid)}).ToList()
+                Deleted = changes.Deleted.Select(d => new ItemDeleted {Key = d.Path, GetValue = () => getBlobValue(d.OldOid)}).ToList()
             };
 
         string getBlobValue(ObjectId objectId) =>


### PR DESCRIPTION
- Do all branch diffs against master
- use callbacks instead of events so we await the handlers
- Do not load all modificactions when diffing, defer this until the event is handled. This should eliminate memory issues